### PR TITLE
fix: Update cache upon saving

### DIFF
--- a/src/Library.tsx
+++ b/src/Library.tsx
@@ -244,6 +244,10 @@ export default function Library() {
     } else {
       dispatch({ type: "CLEAR_ERROR" });
       dispatch({ type: "SET_SAVED", payload: true });
+      // Since we depend on a cache version of the selected book when picking a chapter
+      // we must also set the chapter on said cache whenever save occurs.
+      // This avoids the issue in which switching a chapter looses your last saved work.
+      dispatch({ type: "SET_SELECTED_BOOK_CHAPTER", payload: chapter });
     }
   }
 

--- a/src/reducers/library.tsx
+++ b/src/reducers/library.tsx
@@ -124,6 +124,14 @@ export const reducer = produce<t.State>(
       case "SET_ERROR":
         draft.error = action.payload;
         break;
+      case "SET_SELECTED_BOOK_CHAPTER":
+        const _chapter = action.payload;
+        const idx = draft.selectedBook.chapters.findIndex((sbChapter) => sbChapter.chapterid === _chapter.chapterid);
+
+        if (idx >= 0) {
+          draft.selectedBook.chapters[idx] = _chapter;
+        }
+        break;
       case "CLEAR_ERROR":
         // draft.error = "";
         break;


### PR DESCRIPTION
Currently when you save and then switch chapters, the content for the other chapter pulls from the currentBook cache. In the case where you switch back, you risk losing your work.

this fixes issue #7 

Before
![cache-issue](https://user-images.githubusercontent.com/18686786/232381288-d98330bf-88aa-419f-b0a4-7bdcfb7d4520.gif)


After
![cache-fix](https://user-images.githubusercontent.com/18686786/232381307-bfe4601f-bec1-4d41-a765-56bf097270b4.gif)
