### PR TITLE
fix: eliminate duplicate calls to firestore

### DIFF
--- a/src/storage/firebase.js
+++ b/src/storage/firebase.js
@@ -35,18 +35,20 @@ export const saveBook = async (book) => {
 export const getBook = async (bookid) => {
   console.log("getting book");
   console.log({ bookid });
-  const docRef = db.collection("books").doc(bookid);
-  const bookObj = await docRef.get();
+  const bookRef = db.collection("books").doc(bookid);
+
+  const chapterRef = db
+    .collection("chapters")
+    .where("bookid", "==", bookid);
+
+  const [bookObj, chapters] = await Promise.all([bookRef.get(), chapterRef.get()]);
+
   if (!bookObj.exists) {
     return null;
   }
+
   const book = bookObj.data();
   book.chapters = [];
-  // console.log("1chapters", book.chapters);
-  const chapters = await db
-    .collection("chapters")
-    .where("bookid", "==", bookid)
-    .get();
 
   if (chapters.empty) {
     console.log("No chapters found for this book.");


### PR DESCRIPTION
This reduces the time to get a book and load chapters. By saving the book and chapter to the req.locals, we no longer have to call firestore twice to get it.

This also makes both the request to book and chapters concurrent (well kinda, node is single threaded, you know what I mean) which should help a little.

Before:
![book-timing-before](https://user-images.githubusercontent.com/18686786/232672326-70c2581b-13e9-4439-8482-d5c56e98d004.gif)


After:
![book-timing-fix](https://user-images.githubusercontent.com/18686786/232672335-b67842c4-5669-4328-a71d-04eb3493c5fe.gif)
