### PR TITLE
fix: add public folder as static

### DIFF
--- a/server.js
+++ b/server.js
@@ -42,6 +42,7 @@ app.use(cors());
 app.use(express.json());
 app.use(express.urlencoded());
 
+app.use(express.static("public"));
 app.use(express.static("dist"));
 
 app.use(cookieParser());


### PR DESCRIPTION
This allows for the new favicon to show up as the public folder is now a static asset.