### PR TITLE
fix: remove trailing space from contenteditable

### DIFF
--- a/src/components/ContentEditable.tsx
+++ b/src/components/ContentEditable.tsx
@@ -13,7 +13,8 @@ export default function ContentEditable({
   const [content, setContent] = React.useState(value);
 
   const handleChange = (evt) => {
-    setContent(evt.target.innerHTML.replace(/<br>/g, " "));
+    const value = evt.target.innerHTML.replace(/<br>|&nbsp;/g, " ").trim();
+    setContent(value);
   };
 
   const handleSubmit = () => {


### PR DESCRIPTION
Minor: This remove the `&nsbp!` when someone saves a title with a trailing space.