### PR TITLE
fix: Fix scroll part deux

### DIFF
--- a/pages/admin.html
+++ b/pages/admin.html
@@ -9,7 +9,7 @@
     <title><%= htmlWebpackPlugin.options.title %></title>
     <meta name="csrf-token" content="{{csrfToken}}">
 </head>
-<body class="h-full overflow-scroll bg-background text-text dark:bg-dmbackground dark:text-dmtext">
+<body class="h-screen overflow-hidden bg-background text-text dark:bg-dmbackground dark:text-dmtext">
 
     
     <div id="root"></div>

--- a/pages/book.html
+++ b/pages/book.html
@@ -18,7 +18,7 @@
     <title><%= htmlWebpackPlugin.options.title %></title>
     <meta name="csrf-token" content="{{csrfToken}}">
 </head>
-<body class="h-full overflow-scroll bg-background text-text dark:bg-dmbackground dark:text-dmtext">
+<body class="h-screen overflow-hidden bg-background text-text dark:bg-dmbackground dark:text-dmtext">
 
     
     <div id="root"></div>

--- a/pages/chapter.html
+++ b/pages/chapter.html
@@ -18,7 +18,7 @@
     <title><%= htmlWebpackPlugin.options.title %></title>
     <meta name="csrf-token" content="{{csrfToken}}">
 </head>
-<body class="h-full overflow-scroll bg-background text-text dark:bg-dmbackground dark:text-dmtext">
+<body class="h-screen overflow-hidden bg-background text-text dark:bg-dmbackground dark:text-dmtext">
     
     <div id="root"></div>
 </body>

--- a/pages/home.html
+++ b/pages/home.html
@@ -7,7 +7,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title><%= htmlWebpackPlugin.options.title %></title>
 </head>
-<body class="h-full overflow-scroll bg-background text-text dark:bg-dmbackground dark:text-dmtext">
+<body class="h-screen overflow-hidden bg-background text-text dark:bg-dmbackground dark:text-dmtext">
 
   <div id="root"></div>
 

--- a/pages/library.html
+++ b/pages/library.html
@@ -17,7 +17,7 @@
     </script>
     <meta name="csrf-token" content="{{csrfToken}}">
 </head>
-<body class="h-full overflow-scroll bg-background text-text dark:bg-dmbackground dark:text-dmtext">
+<body class="h-screen overflow-hidden bg-background text-text dark:bg-dmbackground dark:text-dmtext">
 
     
     <div id="root"></div>


### PR DESCRIPTION
To replicate this, create a book and add a number of carriage returns. Notice how the full page will scroll in addition to the editor piece. This is incorrect. 

Now only the editor piece will scroll.