### PR TITLE
Add Redux

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -175,6 +175,9 @@ export default {
   // A map from regular expressions to paths to transformers
   // transform: {},
   extensionsToTreatAsEsm: [".ts", ".tsx"],
+  setupFiles: [
+    "./setupJestMock.ts",
+  ],
 
   // An array of regexp pattern strings that are matched against all source file paths, matched files will skip transformation
   // transformIgnorePatterns: [

--- a/library.tsx
+++ b/library.tsx
@@ -2,11 +2,15 @@ import * as React from "react";
 import * as ReactDOM from "react-dom/client";
 import { BrowserRouter } from "react-router-dom";
 import App from "./src/App";
+import { Provider } from 'react-redux';
+import { store } from './src/store';
 
 const domNode = document.getElementById("root");
 const root = ReactDOM.createRoot(domNode);
 root.render(
-  <BrowserRouter>
-    <App />
-  </BrowserRouter>,
+  <Provider store={store}>
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>
+  </Provider>,
 );

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
   "dependencies": {
     "@headlessui/react": "^1.7.13",
     "@heroicons/react": "^2.0.16",
+    "@reduxjs/toolkit": "^1.9.5",
     "@tailwindcss/forms": "^0.5.3",
     "@types/node": "^18.15.9",
     "cookie-parser": "^1.4.6",
@@ -66,6 +67,7 @@
     "react-dom": "^18.2.0",
     "react-draggable": "^4.4.5",
     "react-quill": "^2.0.0",
+    "react-redux": "^8.0.5",
     "react-router-dom": "^6.9.0",
     "syllable": "^5.0.1"
   },

--- a/setupJestMock.ts
+++ b/setupJestMock.ts
@@ -1,0 +1,17 @@
+const localStorageMock = {
+  store: {},
+  getItem(key) {
+    return this.store[key];
+  },
+  setItem(key, value) {
+    this.store[key] = value.toString();
+  },
+  clear() {
+    this.store = {};
+  },
+  removeItem(key) {
+    delete this.store[key];
+  },
+};
+
+Object.defineProperty(global, 'localStorage', { value: localStorageMock });

--- a/src/BookList.tsx
+++ b/src/BookList.tsx
@@ -9,6 +9,8 @@ import ListItem from "./ListItem";
 import Popup from "./Popup";
 import { getCsrfToken } from "./utils";
 import * as fd from "./fetchData";
+import { useDispatch } from "react-redux";
+import { librarySlice } from "./reducers/librarySlice";
 
 async function deleteBook(bookid: string, onDelete) {
   const res = await fd.deleteBook(bookid);
@@ -36,7 +38,7 @@ async function newBook(dispatch) {
   } else {
     const book = res.payload;
     console.log("new book", book);
-    dispatch({ type: "ADD_BOOK", payload: book });
+    dispatch(librarySlice.actions.addBook(book));
   }
 }
 
@@ -49,7 +51,6 @@ export default function BookList({
   onChange,
   onDelete,
   saveBook,
-  dispatch,
   canCloseSidebar = true,
 }: {
   books: t.Book[];
@@ -57,9 +58,9 @@ export default function BookList({
   onChange: () => void;
   onDelete: (bookid: string) => void;
   saveBook: (book: t.Book) => void;
-  dispatch: React.Dispatch<any>;
   canCloseSidebar?: boolean;
 }) {
+  const dispatch = useDispatch();
   const [showPopup, setShowPopup] = React.useState(false);
   const [currentBook, setCurrentBook] = React.useState(books[0]);
 
@@ -92,7 +93,7 @@ export default function BookList({
   const rightMenuItem = canCloseSidebar && {
     label: "Close",
     icon: <XMarkIcon className="w-4 h-4 xl:w-5 xl:h-5" />,
-    onClick: () => dispatch({ type: "CLOSE_BOOK_LIST" }),
+    onClick: () => dispatch(librarySlice.actions.closeBookList()),
     className: buttonStyles,
   };
 

--- a/src/ChapterList.test.tsx
+++ b/src/ChapterList.test.tsx
@@ -10,6 +10,8 @@ import { BrowserRouter } from "react-router-dom";
 import { render, fireEvent, screen } from "@testing-library/react";
 import "@testing-library/jest-dom";
 import { act } from "react-dom/test-utils";
+import { store } from "./store";
+import { Provider } from 'react-redux';
 
 const props = {
   chapters: [chapter1, chapter2],
@@ -36,9 +38,12 @@ describe("ChapterList", () => {
   let container;
   beforeEach(() => {
     const res = render(
-      <BrowserRouter>
-        <ChapterList {...props} />
-      </BrowserRouter>,
+
+      <Provider store={store}>
+        <BrowserRouter>
+          <ChapterList {...props} />
+        </BrowserRouter>
+      </Provider>,
     );
     container = res.container;
   });

--- a/src/ChapterList.tsx
+++ b/src/ChapterList.tsx
@@ -17,6 +17,8 @@ import ListMenu from "./ListMenu";
 import ListItem from "./ListItem";
 import Popup from "./Popup";
 import { getCsrfToken } from "./utils";
+import { useDispatch } from "react-redux";
+import { librarySlice } from "./reducers/librarySlice";
 // import Draggable from "react-draggable";
 
 export default function ChapterList({
@@ -27,7 +29,6 @@ export default function ChapterList({
   onDelete,
   saveChapter,
   closeSidebar,
-  dispatch,
   canCloseSidebar = true,
 }: {
   chapters: t.Chapter[];
@@ -37,16 +38,16 @@ export default function ChapterList({
   onDelete: any;
   saveChapter: any;
   closeSidebar: () => void;
-  dispatch: React.Dispatch<t.ReducerAction>;
   canCloseSidebar?: boolean;
 }) {
+  const dispatch = useDispatch();
   const [editing, setEditing] = React.useState(false);
   const [showPopup, setShowPopup] = React.useState(false);
   const [currentChapter, setCurrentChapter] = React.useState(chapters[0]);
 
   async function deleteChapter(chapterid: string) {
     console.log("delete chapter", chapterid);
-    dispatch({ type: "LOADING" });
+    dispatch(librarySlice.actions.loading);
     const res = await fetch(`/api/deleteChapter`, {
       method: "POST",
       headers: {
@@ -54,7 +55,7 @@ export default function ChapterList({
       },
       body: JSON.stringify({ bookid, chapterid, csrfToken: getCsrfToken() }),
     });
-    dispatch({ type: "LOADED" });
+    dispatch(librarySlice.actions.loaded);
     if (!res.ok) {
       console.log(res.statusText);
       return;
@@ -64,7 +65,7 @@ export default function ChapterList({
 
   async function favoriteChapter(chapterid: string) {
     console.log("favorite chapter", chapterid);
-    dispatch({ type: "LOADING" });
+    dispatch(librarySlice.actions.loading());
     const res = await fetch(`/api/favoriteChapter`, {
       method: "POST",
       headers: {
@@ -72,7 +73,7 @@ export default function ChapterList({
       },
       body: JSON.stringify({ bookid, chapterid, csrfToken: getCsrfToken() }),
     });
-    dispatch({ type: "LOADED" });
+    dispatch(librarySlice.actions.loaded());
     if (!res.ok) {
       console.log(res.statusText);
       return;
@@ -81,11 +82,11 @@ export default function ChapterList({
   }
 
   const newChapter = async (title = "New Chapter", text = "") => {
-    dispatch({ type: "LOADING" });
+    dispatch(librarySlice.actions.loading());
     const result = await fd.newChapter(bookid, title, text);
-    dispatch({ type: "LOADED" });
+    dispatch(librarySlice.actions.loaded());
     if (result.tag === "error") {
-      dispatch({ type: "SET_ERROR", payload: result.message });
+      dispatch(librarySlice.actions.setError(result.message));
       return;
     }
     await onChange();
@@ -120,7 +121,7 @@ export default function ChapterList({
     const [removed] = ids.splice(result.source.index, 1);
     ids.splice(result.destination.index, 0, removed);
 
-    dispatch({ type: "SET_CHAPTER_ORDER", payload: { bookid, ids } });
+    dispatch(librarySlice.actions.setChapterOrder({ bookid, ids }));
   };
 
   const sublist = () => chapters.map((chapter, index) => (

--- a/src/Editor.tsx
+++ b/src/Editor.tsx
@@ -3,16 +3,17 @@ import "./globals.css";
 import TextEditor from "./TextEditor";
 import * as t from "./Types";
 import { getCsrfToken } from "./utils";
+import { useDispatch, useSelector } from "react-redux";
+import { RootState } from "./store";
+import { librarySlice } from "./reducers/librarySlice";
 
 export default function Editor({
-  state,
-  dispatch,
   onSave,
 }: {
-  state: t.State;
-  dispatch: React.Dispatch<t.ReducerAction>;
   onSave: (state: t.State) => void;
 }) {
+  const state = useSelector((state: RootState) => state.library);
+  const dispatch = useDispatch();
   async function saveChapter(state: t.State) {
     if (state.saved) return;
     if (!state.chapter) {
@@ -33,10 +34,10 @@ export default function Editor({
     });
 
     if (!result.ok) {
-      dispatch({ type: "SET_ERROR", payload: result.statusText });
+      dispatch(librarySlice.actions.setError(result.statusText));
     } else {
-      dispatch({ type: "CLEAR_ERROR" });
-      dispatch({ type: "SET_SAVED", payload: true });
+      dispatch(librarySlice.actions.clearError());
+      dispatch(librarySlice.actions.setSaved(true));
     }
   }
 
@@ -57,8 +58,6 @@ export default function Editor({
         </div>
         <div className="h-full w-full">
           <TextEditor
-            dispatch={dispatch as any}
-            state={state.editor}
             chapterid={state.chapter.chapterid}
             saved={state.saved}
             onSave={() => onSave(state)}

--- a/src/PromptsSidebar.tsx
+++ b/src/PromptsSidebar.tsx
@@ -7,20 +7,21 @@ import * as fd from "./fetchData";
 import List from "./components/List";
 import Spinner from "./components/Spinner";
 import { fetchSuggestionsWrapper } from "./utils";
+import { useDispatch, useSelector } from "react-redux";
+import { RootState } from "./store";
+import { librarySlice } from "./reducers/librarySlice";
 
 export default function PromptsSidebar({
-  dispatch,
-  state,
   settings,
   closeSidebar,
   onLoad,
 }: {
-  dispatch: (action: any) => t.State;
-  state: t.EditorState;
   settings: t.UserSettings;
   closeSidebar: () => void;
   onLoad: () => void;
 }) {
+  const state = useSelector((state: RootState) => state.library.editor);
+  const dispatch = useDispatch();
   const [loading, setLoading] = useState(false);
 
   const fetchSynonyms = async () => {
@@ -40,13 +41,8 @@ export default function PromptsSidebar({
 
     const synonyms = response.map((item) => item.word);
     console.log("synonyms", synonyms);
-    dispatch({
-      type: "ADD_SUGGESTION",
-      label: "Synonyms",
-      payload: synonyms.join(", "),
-    });
-
-    dispatch({ type: "SET_SAVED", payload: false });
+    dispatch(librarySlice.actions.addSuggestion({ label: 'Synonyms', value: synonyms.join(', ') }));
+    dispatch(librarySlice.actions.setSaved(false));
     setLoading(false);
     onLoad();
   };
@@ -55,10 +51,8 @@ export default function PromptsSidebar({
     <li
       key={i}
       onClick={() => fetchSuggestionsWrapper(
-        state,
         settings,
         setLoading,
-        dispatch,
         onLoad,
         prompt.text,
         prompt.label,

--- a/src/Sidebar.tsx
+++ b/src/Sidebar.tsx
@@ -14,6 +14,9 @@ import SuggestionPanel from "./SuggestionPanel";
 import Info from "./Info";
 import List from "./components/List";
 import NavButton from "./NavButton";
+import { useDispatch, useSelector } from "react-redux";
+import { RootState } from "./store";
+import { librarySlice } from "./reducers/librarySlice";
 
 function Suggestions({ suggestions, onClick, onDelete }) {
   return (
@@ -114,7 +117,6 @@ function Navigation({
 }
 
 export default function Sidebar({
-  state,
   settings,
   setSettings,
   activePanel,
@@ -125,8 +127,10 @@ export default function Sidebar({
   onHistoryClick,
   triggerHistoryRerender,
   maximize,
-  dispatch,
 }) {
+  const state = useSelector((state: RootState) => state.library);
+  const dispatch = useDispatch();
+
   const infoText = state.editor.selectedText.length === 0
     ? state.editor.text
     : state.editor.selectedText.contents;
@@ -135,10 +139,10 @@ export default function Sidebar({
       <div className="pt-xs">
         <Navigation
           onClick={setActivePanel}
-          closeSidebar={() => dispatch({ type: "CLOSE_SIDEBAR" })}
+          closeSidebar={() => dispatch(librarySlice.actions.closeSidebar())}
           maximize={maximize}
-          fullscreen={() => dispatch({ type: "SET_VIEW_MODE", payload: "fullscreen" })}
-          exitFullscreen={() => dispatch({ type: "SET_VIEW_MODE", payload: "default" })}
+          fullscreen={() => dispatch(librarySlice.actions.setViewMode("fullscreen"))}
+          exitFullscreen={() => dispatch(librarySlice.actions.setViewMode("default"))}
         />
         {activePanel === "info" && (
           <List

--- a/src/Types.ts
+++ b/src/Types.ts
@@ -44,6 +44,8 @@ export type EditorState = {
   _cachedSelectedText?: SelectedText;
   _pushTextToEditor?: string;
 
+  _pushContentToEditor?: string;
+
   // selectedSyllables: number;
 };
 

--- a/src/reducers/librarySlice.ts
+++ b/src/reducers/librarySlice.ts
@@ -1,0 +1,345 @@
+import * as toolkitRaw from '@reduxjs/toolkit';
+import type { PayloadAction } from '@reduxjs/toolkit';
+import * as t from "../Types";
+import { localStorageOrDefault } from "../utils";
+
+// @ts-ignore
+const { createSlice } = toolkitRaw.default ?? toolkitRaw;
+
+type DefaultChapter = {
+  title: string;
+  text: string;
+  chapterid: string;
+  suggestions: string[];
+};
+
+const defaults = {
+  title: "",
+  text: "",
+  chapterid: "",
+  suggestions: [],
+};
+
+const initialEditorState = (
+  _chapter: t.Chapter | DefaultChapter,
+): t.EditorState => {
+  const chapter = _chapter || defaults;
+  return {
+    title: chapter.title,
+    text: chapter.text,
+    contents: {},
+    chapterid: chapter.chapterid,
+    tooltipPosition: { top: 0, left: 0 },
+    tooltipOpen: false,
+    selectedText: { index: 0, length: 0, contents: "" },
+  };
+};
+
+export const initialState = (_chapter: t.Chapter | null): t.State => {
+  const chapter = _chapter || defaults;
+  return {
+    books: [],
+    selectedBook: null,
+    editor: initialEditorState(chapter),
+    chapter: _chapter,
+    synonyms: [],
+    infoPanel: { syllables: 0 },
+    panels: {
+      bookList: {
+        open: localStorageOrDefault("bookListOpen", true),
+      },
+      chapterList: {
+        open: localStorageOrDefault("chapterListOpen", true),
+      },
+      sidebar: {
+        open: localStorageOrDefault("sidebarOpen", false),
+        activePanel: localStorageOrDefault("activePanel", "suggestions"),
+      },
+      prompts: {
+        open: localStorageOrDefault("promptsOpen", false),
+      },
+    },
+    suggestions: chapter.suggestions,
+    saved: true,
+    error: "",
+    loading: true,
+    viewMode: "default",
+    launcherOpen: false,
+  };
+};
+
+export const librarySlice = createSlice({
+  name: 'library',
+  initialState: initialState(null),
+  reducers: {
+    setBooks(state, action: PayloadAction<t.Book[]>) {
+      state.books = action.payload;
+    },
+    addBook(state, action: PayloadAction<t.Book>) {
+      state.books.push(action.payload);
+    },
+    setBook(state, action: PayloadAction<t.Book>) {
+      state.selectedBook = action.payload;
+    },
+    deleteBook(state, action: PayloadAction<string>) {
+      const bookid = action.payload;
+      state.books = state.books.filter((book) => book.bookid !== bookid);
+    },
+    deleteChapter(state, action: PayloadAction<string>) {
+      const chapterid = action.payload;
+
+      state.selectedBook.chapters = state.selectedBook.chapters.filter((chapter) => chapter.chapterid !== chapterid);
+
+      state.selectedBook.chapterTitles = state.selectedBook.chapterTitles.filter(
+        (chapter) => chapter.chapterid !== chapterid,
+      );
+    },
+    setChapter(state, action) {
+      const chapter = action.payload;
+      state.editor = initialEditorState(chapter);
+      state.chapter = chapter;
+      state.suggestions = chapter.suggestions;
+    },
+    setNoChapter(state) {
+      state.editor = initialEditorState(null);
+      state.chapter = null;
+      state.suggestions = [];
+    },
+    setError(state, action) {
+      state.error = action.payload;
+    },
+    clearError(state) {
+      state.error = "";
+    },
+    loading(state) {
+      state.loading = true;
+    },
+    loaded(state) {
+      state.loading = false;
+    },
+    setText(state, action) {
+      state.editor.text = action.payload;
+      state.chapter.text = action.payload;
+      state.saved = false;
+    },
+    pushTextToEditor(state, action) {
+      state.editor.text = action.payload;
+      state.editor._pushTextToEditor = action.payload;
+      state.chapter.text = action.payload;
+      state.saved = false;
+    },
+    setTitle(state, action) {
+      state.editor.title = action.payload;
+      state.chapter.title = action.payload;
+      // find chapter and then update it so that the chapter list also receives the update.
+      let chapterIdx = state.selectedBook.chapters.findIndex(
+        (chapter) => chapter.chapterid === state.chapter.chapterid,
+      );
+
+      if (chapterIdx !== -1) {
+        state.selectedBook.chapters[chapterIdx].title = action.payload;
+      }
+
+      chapterIdx = state.selectedBook.chapterTitles.findIndex(
+        (chapter) => chapter.chapterid === state.chapter.chapterid,
+      );
+
+      if (chapterIdx !== -1) {
+        state.selectedBook.chapterTitles[chapterIdx].title = action.payload;
+      }
+      state.saved = false;
+    },
+    setLoadedChapterData(state, action) {
+      state.chapter = action.payload.chapter;
+      state.suggestions = action.payload.suggestions;
+      state.editor.text = action.payload.text;
+      state.editor.title = action.payload.title;
+      state.editor.chapterid = action.payload.chapterid;
+    },
+    setSuggestions(state, action) {
+      if (action.payload) {
+        state.suggestions = action.payload;
+        state.saved = false;
+      }
+    },
+    setSaved(state, action) {
+      state.saved = action.payload;
+    },
+    setSelectedBookChapter(state, action) {
+      const _chapter = action.payload;
+      const idx = state.selectedBook.chapters.findIndex(
+        (sbChapter) => sbChapter.chapterid === _chapter.chapterid,
+      );
+
+      if (idx >= 0) {
+        state.selectedBook.chapters[idx] = _chapter;
+      }
+    },
+    addToContents(state, action) {
+      state.editor._pushContentToEditor = action.payload;
+      state.editor.text += action.payload;
+      state.saved = false;
+    },
+    setSynonyms(state, action) {
+      state.synonyms = action.payload;
+    },
+    clearSynonyms(state, action) {
+      state.synonyms = [];
+    },
+    setTooltipPosition(state, action) {
+      state.editor.tooltipPosition = action.payload;
+    },
+    openTooltip(state) {
+      state.editor.tooltipOpen = true;
+    },
+    closeTooltip(state) {
+      state.editor.tooltipOpen = false;
+    },
+    setSelectedText(state, action) {
+      state.editor.selectedText = action.payload;
+    },
+    clearSelectedText(state) {
+      state.editor._cachedSelectedText = state.editor.selectedText;
+      state.editor.selectedText = { index: 0, length: 0, contents: "" };
+      console.log(
+        "clearing selected text",
+        state.editor._cachedSelectedText,
+        state.editor.selectedText,
+      );
+    },
+    synonymSelected(state, action) {
+      state.editor.selectedText = action.payload;
+      state.editor.tooltipOpen = false;
+    },
+    addSuggestion(state, action) {
+      state.suggestions.push({
+        type: action.payload.label,
+        contents: action.payload.value,
+      });
+      state.saved = false;
+    },
+    deleteSuggestion(state, action) {
+      state.suggestions.splice(action.payload, 1);
+      state.saved = false;
+    },
+    setAllNewState(state, action) {
+      // eslint-disable-next-line
+      return action.payload;
+    },
+    setChapterOrder(state, action) {
+      const { ids, bookid } = action.payload;
+      console.log(ids);
+      const newTitles = [];
+      ids.forEach((id) => {
+        const chapter = state.selectedBook.chapterTitles.find(
+          (chapter) => chapter.chapterid === id,
+        );
+        if (chapter) {
+          newTitles.push(chapter);
+        }
+      });
+      state.selectedBook.chapterTitles = newTitles;
+      state.saved = false;
+    },
+    setTemporaryFocusModeState(state, action) {
+      state._temporaryFocusModeState = action.payload;
+    },
+    setViewMode(state, action) {
+      state.viewMode = action.payload;
+    },
+    openBookList(state) {
+      state.panels.bookList.open = true;
+      localStorage.setItem("bookListOpen", "true");
+    },
+    closeBookList(state) {
+      state.panels.bookList.open = false;
+      localStorage.setItem("bookListOpen", "false");
+    },
+    openChapterList(state) {
+      state.panels.chapterList.open = true;
+      localStorage.setItem("chapterListOpen", "true");
+    },
+    closeChapterList(state) {
+      state.panels.chapterList.open = false;
+      localStorage.setItem("chapterListOpen", "false");
+    },
+    openSidebar(state) {
+      state.panels.sidebar.open = true;
+      localStorage.setItem("sidebarOpen", "true");
+    },
+    closeSidebar(state) {
+      state.panels.sidebar.open = false;
+      localStorage.setItem("sidebarOpen", "false");
+    },
+    openPrompts(state) {
+      state.panels.prompts.open = true;
+      localStorage.setItem("promptsOpen", "true");
+    },
+    closePrompts(state) {
+      state.panels.prompts.open = false;
+      localStorage.setItem("promptsOpen", "false");
+    },
+    toggleBookList(state) {
+      state.panels.bookList.open = !state.panels.bookList.open;
+      localStorage.setItem(
+        "bookListOpen",
+        state.panels.bookList.open ? "true" : "false",
+      );
+    },
+    toggleChapterList(state) {
+      state.panels.chapterList.open = !state.panels.chapterList.open;
+      localStorage.setItem(
+        "chapterListOpen",
+        state.panels.chapterList.open ? "true" : "false",
+      );
+    },
+    toggleSidebar(state) {
+      state.panels.sidebar.open = !state.panels.sidebar.open;
+      localStorage.setItem(
+        "sidebarOpen",
+        state.panels.sidebar.open ? "true" : "false",
+      );
+    },
+    togglePrompts(state) {
+      state.panels.prompts.open = !state.panels.prompts.open;
+      localStorage.setItem(
+        "promptsOpen",
+        state.panels.prompts.open ? "true" : "false",
+      );
+    },
+    closeAllPanels(state) {
+      state.panels.bookList.open = false;
+      state.panels.chapterList.open = false;
+      state.panels.sidebar.open = false;
+      state.panels.prompts.open = false;
+      localStorage.setItem("bookListOpen", "false");
+      localStorage.setItem("chapterListOpen", "false");
+      localStorage.setItem("sidebarOpen", "false");
+      localStorage.setItem("promptsOpen", "false");
+    },
+    openAllPanels(state) {
+      state.panels.bookList.open = true;
+      state.panels.chapterList.open = true;
+      state.panels.sidebar.open = true;
+      state.panels.prompts.open = true;
+      localStorage.setItem("bookListOpen", "true");
+      localStorage.setItem("chapterListOpen", "true");
+      localStorage.setItem("sidebarOpen", "true");
+      localStorage.setItem("promptsOpen", "true");
+    },
+    setActivePanel(state, action) {
+      state.panels.sidebar.activePanel = action.payload;
+      localStorage.setItem("activePanel", action.payload);
+    },
+    toggleLauncher(state) {
+      state.launcherOpen = !state.launcherOpen;
+    },
+    noBookSelected(state) {
+      state.selectedBook = null;
+      state.chapter = null;
+    },
+    noChapterSelected(state) {
+      state.chapter = null;
+    },
+  },
+});

--- a/src/store.ts
+++ b/src/store.ts
@@ -1,0 +1,15 @@
+import * as toolkitRaw from '@reduxjs/toolkit';
+import { librarySlice } from "./reducers/librarySlice";
+
+// @ts-ignore
+const { configureStore } = toolkitRaw.default ?? toolkitRaw;
+
+export const store = configureStore({
+  reducer: {
+    library: librarySlice.reducer,
+  },
+});
+
+// Infer the `RootState` and `AppDispatch` types from the store itself
+export type RootState = ReturnType<typeof store.getState>
+export type AppDispatch = typeof store.dispatch

--- a/yarn.lock
+++ b/yarn.lock
@@ -1039,7 +1039,7 @@
   resolved "https://registry.yarnpkg.com/@babel/regjsgen/-/regjsgen-0.8.0.tgz#f0ba69b075e1f05fb2825b7fad991e7adbb18310"
   integrity sha512-x/rqGMdzj+fWZvCOYForTghzbtqPDZ5gPwaoNGHdgDfF2QA/XZbCBp4Moo5scrkAMPhB7z26XM/AaHuIJdgauA==
 
-"@babel/runtime@^7.12.5", "@babel/runtime@^7.15.4", "@babel/runtime@^7.20.7", "@babel/runtime@^7.8.4", "@babel/runtime@^7.9.2":
+"@babel/runtime@^7.12.1", "@babel/runtime@^7.12.5", "@babel/runtime@^7.15.4", "@babel/runtime@^7.20.7", "@babel/runtime@^7.8.4", "@babel/runtime@^7.9.2":
   version "7.21.0"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.21.0.tgz#5b55c9d394e5fcf304909a8b00c07dc217b56673"
   integrity sha512-xwII0//EObnq89Ji5AKYQaRYiW/nZ3llSv29d49IuxPhKbtJoLP+9QUUZ4nVragQVtaVGeZrpB+ZtG/Pdy/POw==
@@ -2212,6 +2212,16 @@
   resolved "https://registry.yarnpkg.com/@protobufjs/utf8/-/utf8-1.1.0.tgz#a777360b5b39a1a2e5106f8e858f2fd2d060c570"
   integrity sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==
 
+"@reduxjs/toolkit@^1.9.5":
+  version "1.9.5"
+  resolved "https://registry.yarnpkg.com/@reduxjs/toolkit/-/toolkit-1.9.5.tgz#d3987849c24189ca483baa7aa59386c8e52077c4"
+  integrity sha512-Rt97jHmfTeaxL4swLRNPD/zV4OxTes4la07Xc4hetpUW/vc75t5m1ANyxG6ymnEQ2FsLQsoMlYB2vV1sO3m8tQ==
+  dependencies:
+    immer "^9.0.21"
+    redux "^4.2.1"
+    redux-thunk "^2.4.2"
+    reselect "^4.1.8"
+
 "@remix-run/router@1.4.0":
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/@remix-run/router/-/router-1.4.0.tgz#74935d538e4df8893e47831a7aea362f295bcd39"
@@ -2414,7 +2424,7 @@
   dependencies:
     "@types/node" "*"
 
-"@types/hoist-non-react-statics@^3.3.0":
+"@types/hoist-non-react-statics@^3.3.0", "@types/hoist-non-react-statics@^3.3.1":
   version "3.3.1"
   resolved "https://registry.yarnpkg.com/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz#1124aafe5118cb591977aeb1ceaaed1070eb039f"
   integrity sha512-iMIqiko6ooLrTh1joXodJK5X9xeEALT1kM5G3ZLhD3hszxBdIEd5C75U834D9mLcINgD4OyZf5uQXjkuYydWvA==
@@ -2679,6 +2689,11 @@
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/@types/tough-cookie/-/tough-cookie-4.0.2.tgz#6286b4c7228d58ab7866d19716f3696e03a09397"
   integrity sha512-Q5vtl1W5ue16D+nIaW8JWebSSraJVlK+EthKn7e7UcD4KWsaSJ8BqGPXNaPghgtcn/fhvrN17Tv8ksUsQpiplw==
+
+"@types/use-sync-external-store@^0.0.3":
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/@types/use-sync-external-store/-/use-sync-external-store-0.0.3.tgz#b6725d5f4af24ace33b36fafd295136e75509f43"
+  integrity sha512-EwmlvuaxPNej9+T4v5AuBPJa2x2UOJVdjCtDHgcDqitUeOtjnJKJ+apYjVcAoBEMjKW1VVFGZLUb5+qqa09XFA==
 
 "@types/ws@^8.5.1":
   version "8.5.4"
@@ -5902,6 +5917,11 @@ immer@^9.0.19:
   resolved "https://registry.yarnpkg.com/immer/-/immer-9.0.19.tgz#67fb97310555690b5f9cd8380d38fc0aabb6b38b"
   integrity sha512-eY+Y0qcsB4TZKwgQzLaE/lqYMlKhv5J9dyd2RhhtGhNo2njPXDqU9XPfcNfa3MIDsdtZt5KlkIsirlo4dHsWdQ==
 
+immer@^9.0.21:
+  version "9.0.21"
+  resolved "https://registry.yarnpkg.com/immer/-/immer-9.0.21.tgz#1e025ea31a40f24fb064f1fef23e931496330176"
+  integrity sha512-bc4NBHqOqSfRW7POMkHd51LvClaeMXpm8dx0e8oE2GORbq5aRK7Bxl4FyzVLdGtLmvLKL7BTDBG5ACQm4HWjTA==
+
 immutable@^4.0.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/immutable/-/immutable-4.3.0.tgz#eb1738f14ffb39fd068b1dbe1296117484dd34be"
@@ -8470,6 +8490,18 @@ react-redux@^7.2.0:
     prop-types "^15.7.2"
     react-is "^17.0.2"
 
+react-redux@^8.0.5:
+  version "8.0.5"
+  resolved "https://registry.yarnpkg.com/react-redux/-/react-redux-8.0.5.tgz#e5fb8331993a019b8aaf2e167a93d10af469c7bd"
+  integrity sha512-Q2f6fCKxPFpkXt1qNRZdEDLlScsDWyrgSj0mliK59qU6W5gvBiKkdMEG2lJzhd1rCctf0hb6EtePPLZ2e0m1uw==
+  dependencies:
+    "@babel/runtime" "^7.12.1"
+    "@types/hoist-non-react-statics" "^3.3.1"
+    "@types/use-sync-external-store" "^0.0.3"
+    hoist-non-react-statics "^3.3.2"
+    react-is "^18.0.0"
+    use-sync-external-store "^1.0.0"
+
 react-router-dom@^6.9.0:
   version "6.9.0"
   resolved "https://registry.yarnpkg.com/react-router-dom/-/react-router-dom-6.9.0.tgz#dd8b4e461453bd4cad2e6404493d1a5b4bfea758"
@@ -8560,7 +8592,12 @@ redent@^3.0.0:
     indent-string "^4.0.0"
     strip-indent "^3.0.0"
 
-redux@^4.0.0, redux@^4.0.4:
+redux-thunk@^2.4.2:
+  version "2.4.2"
+  resolved "https://registry.yarnpkg.com/redux-thunk/-/redux-thunk-2.4.2.tgz#b9d05d11994b99f7a91ea223e8b04cf0afa5ef3b"
+  integrity sha512-+P3TjtnP0k/FEjcBL5FZpoovtvrTNT/UXd4/sluaSyrURlSlhLSzEdfsTBW7WsKB6yPvgd7q/iZPICFjW4o57Q==
+
+redux@^4.0.0, redux@^4.0.4, redux@^4.2.1:
   version "4.2.1"
   resolved "https://registry.yarnpkg.com/redux/-/redux-4.2.1.tgz#c08f4306826c49b5e9dc901dee0452ea8fce6197"
   integrity sha512-LAUYz4lc+Do8/g7aeRa8JkyDErK6ekstQaqWQrNRW//MY1TvCEpMtpTWvlQ+FPbWCx+Xixu/6SHt5N0HR+SB4w==
@@ -8668,6 +8705,11 @@ requizzle@^0.2.3:
   integrity sha512-JRrFk1D4OQ4SqovXOgdav+K8EAhSB/LJZqCz8tbX0KObcdeM15Ss59ozWMBWmmINMagCwmqn4ZNryUGpBsl6Jw==
   dependencies:
     lodash "^4.17.21"
+
+reselect@^4.1.8:
+  version "4.1.8"
+  resolved "https://registry.yarnpkg.com/reselect/-/reselect-4.1.8.tgz#3f5dc671ea168dccdeb3e141236f69f02eaec524"
+  integrity sha512-ab9EmR80F/zQTMNeneUr4cv+jSwPJgIlvEmVwLerwrWVbpLlBuls9XHzIeTFy4cegU2NHBp3va0LKOzU5qFEYQ==
 
 resolve-cwd@^3.0.0:
   version "3.0.0"
@@ -9668,6 +9710,11 @@ use-memo-one@^1.1.1:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/use-memo-one/-/use-memo-one-1.1.3.tgz#2fd2e43a2169eabc7496960ace8c79efef975e99"
   integrity sha512-g66/K7ZQGYrI6dy8GLpVcMsBp4s17xNkYJVSMvTEevGy3nDxHOfE6z8BVE22+5G5x7t3+bhzrlTDB7ObrEE0cQ==
+
+use-sync-external-store@^1.0.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz#7dbefd6ef3fe4e767a0cf5d7287aacfb5846928a"
+  integrity sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==
 
 util-deprecate@^1.0.1, util-deprecate@^1.0.2, util-deprecate@~1.0.1:
   version "1.0.2"


### PR DESCRIPTION

This adds redux to the app, replace our own built in state module. I have manually tested a number of things and have ensured the current test work. With that said, I recommend you verify this too.

This is all following the quick start guide: https://redux-toolkit.js.org/tutorials/quick-start

Why redux:
Given that we are using immer and a single reducer, Redux provides us the same functionality, but with significantly better dev tools to watch state.

In the longterm, we should start using middleware to perform requests, which will help simplify the flow significantly, and allow us to better track where and when requests are being made. One of the cool things about Redux Tool Kit (which is what I am using) is that it provides something calls RTKQuery. This will allow us to handle loading states and such for requests a lot easier, and not have to create different actions to do so.

The app with Redux Dev Tools:

![dev-tools](https://user-images.githubusercontent.com/18686786/233798807-7fe4fcf7-405d-49c2-8759-06d16974187b.gif)