### PR TITLE
fix: fix scroll for submenu

### DIFF
--- a/src/ListMenu.tsx
+++ b/src/ListMenu.tsx
@@ -32,7 +32,7 @@ export default function ListMenu({
         leaveFrom="opacity-100 translate-y-0"
         leaveTo="opacity-0 translate-y-1"
       >
-        <Popover.Panel className="absolute left-1/2 z-10 mt-5 flex w-screen max-w-min -translate-x-1/2 px-4">
+        <Popover.Panel className="absolute left-1/2 z-10 mt-5 flex w-screen max-w-min -translate-x-3/4 px-4">
           <div className="rounded-md bg-menu dark:bg-dmmenu p-xs text-sm text-black dark:text-gray-300 gap-1 shadow-2xl ring-1 ring-black ring-opacity-5">
             {items.map((item, index) => (
               <div

--- a/src/components/List.tsx
+++ b/src/components/List.tsx
@@ -93,7 +93,7 @@ export default function List({
 
   return (
     <div
-      className={`p-xs border-r border-listBorder dark:border-dmlistBorder h-screen overflow-scroll w-full ${className} ${
+      className={`p-xs border-r border-listBorder dark:border-dmlistBorder h-screen overflow-y-scroll overflow-x-hidden w-full ${className} ${
         dragOver && "dark:bg-gray-700"
       } `}
       onDragOver={(e) => {


### PR DESCRIPTION
Somewhat of a hack to fix scrolling sideways on a menu. There are much more complex solutions to this, this is the simplest one of just moving it to the left and calling it a day. I think this will be good enough for display purposes for the short term.

Before
![broken-menu](https://user-images.githubusercontent.com/18686786/234453950-f10f869b-34cc-4a3c-9f18-eb49d23413d3.gif)


After
![fix-menu](https://user-images.githubusercontent.com/18686786/234453960-c0d3657a-e198-474e-a841-6be7e4112061.gif)
