### PR TITLE
fix: fix focus for short text

### DIFF
--- a/src/FocusMode.tsx
+++ b/src/FocusMode.tsx
@@ -357,7 +357,7 @@ export default function FocusMode({ text, onClose, onChange }) {
           />
         </div>
         <div className="mt-8 pt-xs">
-          <div style={{"height": "calc(100vh - 10rem)"}} className="overflow-scroll mt-5 flex-grow flex max-w-screen-md mx-auto flex-wrap gap-xs">
+          <div style={{"height": "calc(100vh - 10rem)"}} className="overflow-scroll mt-5 flex-grow flex max-w-screen-md mx-auto flex-wrap gap-xs content-start">
             {wordComponents}
           </div>
         </div>


### PR DESCRIPTION
This fixes the focus for shorter text

Before
<img width="1278" alt="Screenshot 2023-04-25 at 8 33 20 PM" src="https://user-images.githubusercontent.com/18686786/234463214-e2dc1967-c651-496c-a968-7c4e6a4e5251.png">


After
<img width="1290" alt="Screenshot 2023-04-25 at 8 32 57 PM" src="https://user-images.githubusercontent.com/18686786/234463223-c2dc0741-4ecb-4595-94e8-8bf6579fa738.png">
